### PR TITLE
Some recent changes you might want to merge

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -7,7 +7,7 @@ CFLAGS =-std=gnu99 -D_FILE_OFFSET_BITS=64 -DENABLE_SSL -DENABLE_IPV6 -Wall -Wfat
 LIBS = -lssl -lcrypto -lpthread
 PROG = xdccget
 
-SRCS = xdccget.c config.c helper.c argument_parser.c libircclient-src/libircclient.c sds.c dirs.c file.c hashing_algo.c sph_md5.c
+SRCS = xdccget.c config.c helper.c argument_parser.c libircclient-src/libircclient.c sds.c dirs.c file.c hashing_algo.c
 
 all: build
 

--- a/argument_parser.c
+++ b/argument_parser.c
@@ -11,7 +11,7 @@ const char *argp_program_bug_address ="<nobody@nobody.org>";
 
 /* Program documentation. */
 static char doc[] =
-"xdccgget -- download from cmd with xdcc";
+"xdccget -- download from cmd with xdcc";
 
 /* A description of the arguments we accept. */
 static char args_doc[] = "<server> <channel(s)> <bot cmds>";

--- a/hashing_algo.c
+++ b/hashing_algo.c
@@ -1,33 +1,36 @@
 #include <strings.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <openssl/md5.h>
 
 #include "hashing_algo.h"
 #include "file.h"
-#include "sph_md5.h"
+
+int md5_equal(unsigned char hash1[], unsigned char hash2[]) {
+	return memcmp(hash1, hash2, MD5_DIGEST_LENGTH) == 0;
+}
 
 void freeHashAlgo(HashAlgorithm *algo) {
     free(algo->ctx);
     free(algo);
 }
 
-static HashAlgorithm* createMD5SPH() {
+static HashAlgorithm* createMD5() {
     HashAlgorithm *md5 = (HashAlgorithm*) malloc(sizeof (HashAlgorithm));
-    sph_md5_context *md5_context = (sph_md5_context*) malloc(sizeof (sph_md5_context));
-    md5->hashType = MD5;
+    MD5_CTX *md5_context = (MD5_CTX*) malloc(sizeof (MD5_CTX));
+    md5->hashType = HashType_MD5;
     md5->ctx = (void*) md5_context;
-    md5->hashSize = MD5_SIZE;
-    md5->toString = md5_toString;
-    md5->equals = md5_equal_sph;
-    md5->init = md5_init_sph;
-    md5->update = md5_update_sph;
-    md5->final = md5_final_sph;
+    md5->hashSize = MD5_DIGEST_LENGTH;
+    md5->equals = md5_equal;
+    md5->init = MD5_Init;
+    md5->update = MD5_Update;
+    md5->final = MD5_Final;
     return md5;
 }
 
 HashAlgorithm* createHashAlgorithm(char *hashAlgorithm) {
     if (!strcmp("MD5", hashAlgorithm)) {
-        return createMD5SPH();
+        return createMD5();
     }
     else {
         return NULL;
@@ -36,29 +39,29 @@ HashAlgorithm* createHashAlgorithm(char *hashAlgorithm) {
 
 static void updateHash(void *buffer, unsigned int bytesRead, void *ctx) {
     HashAlgorithm *algo = (HashAlgorithm*) ctx;
-    algo->update(algo->ctx, (uchar*) buffer, bytesRead);
+    algo->update(algo->ctx, buffer, bytesRead);
 }
 
-void getHashFromFile(HashAlgorithm *algo, char *filename, uchar *hash) {
+void getHashFromFile(HashAlgorithm *algo, char *filename, unsigned char *hash) {
     algo->init(algo->ctx);
     readFile(filename, updateHash, algo);
-    algo->final(algo->ctx, hash);
+    algo->final(hash, algo->ctx);
 }
 
-void getHashFromStringIter(HashAlgorithm *algo, char *string, uchar *hash, int numIterations) {
+void getHashFromStringIter(HashAlgorithm *algo, char *string, unsigned char *hash, int numIterations) {
     int i = 0;
     algo->init(algo->ctx);
     for (i = 0; i < numIterations; i++) {
-        algo->update(algo->ctx, (uchar*) string, strlen(string));
+        algo->update(algo->ctx, (const void**)&string, strlen(string));
     }
-    algo->final(algo->ctx, hash);
+    algo->final(hash, algo->ctx);
 }
 
-void getHashFromString(HashAlgorithm *algo, char *string, uchar *hash) {
+void getHashFromString(HashAlgorithm *algo, char *string, unsigned char *hash) {
     getHashFromStringIter(algo, string, hash, 1);
 }
 
-static uchar hexCharToBin(char c) {
+static unsigned char hexCharToBin(char c) {
     if (c >= '0' && c <= '9') {
         return c - '0';
     } else if (c >= 'a' && c <= 'f') {
@@ -70,16 +73,16 @@ static uchar hexCharToBin(char c) {
     }
 }
 
-static uchar hexToBin(char c1, char c2) {
-    uchar temp = 0;
+static unsigned char hexToBin(char c1, char c2) {
+    unsigned char temp = 0;
     temp = hexCharToBin(c2);
     temp |= hexCharToBin(c1) << 4;
     return temp;
 }
 
-uchar* convertHashStringToBinary(HashAlgorithm *algo, char *hashString) {
+unsigned char* convertHashStringToBinary(HashAlgorithm *algo, char *hashString) {
    unsigned int i, j;
-    uchar *hashBinary = (uchar*) malloc(sizeof (uchar) * algo->hashSize);
+    unsigned char *hashBinary = (unsigned char*) malloc(sizeof (unsigned char) * algo->hashSize);
     for (i = 0, j = 0; i < algo->hashSize; i++, j += 2) {
         hashBinary[i] = hexToBin(hashString[j], hashString[j + 1]);
     }

--- a/hashing_algo.h
+++ b/hashing_algo.h
@@ -12,24 +12,23 @@
 extern "C" {
 #endif
 
-#include "hash_types.h"
+#include <openssl/md5.h>
 
     enum HashTypes {
-        MD5
+        HashType_MD5
     };
 
     typedef char* (*hash_toString_fct)(unsigned char* hash);
     typedef int (*hash_equals_fct)(unsigned char hash1[], unsigned char hash2[]);
-    typedef void (*hash_init_fct)(void *ctx);
-    typedef void (*hash_update_fct)(void *ctx, uchar data[], uint len);
-    typedef void (*hash_final_fct)(void *ctx, uchar hash[]);
+    typedef int (*hash_init_fct)(MD5_CTX *ctx);
+    typedef int (*hash_update_fct)(MD5_CTX *ctx, const void *data, size_t len);
+    typedef int (*hash_final_fct)(unsigned char *md, MD5_CTX *ctx);
     typedef int (*hash_len)(void *ctx);
 
     struct HashAlgorithm {
         enum HashTypes hashType;
-        void *ctx;
+        MD5_CTX *ctx;
         unsigned int hashSize;
-        hash_toString_fct toString;
         hash_equals_fct equals;
         hash_init_fct init;
         hash_update_fct update;
@@ -41,10 +40,10 @@ extern "C" {
     HashAlgorithm* createHashAlgorithm(char *hashAlgorithm);
     void freeHashAlgo(HashAlgorithm *algo);
 
-    void getHashFromFile(HashAlgorithm *algo, char *filename, uchar *hash);
-    void getHashFromString(HashAlgorithm *algo, char *string, uchar *hash);
-    void getHashFromStringIter(HashAlgorithm *algo, char *string, uchar *hash, int numIterations);
-    uchar* convertHashStringToBinary(HashAlgorithm *algo, char *hashString);
+    void getHashFromFile(HashAlgorithm *algo, char *filename, unsigned char *hash);
+    void getHashFromString(HashAlgorithm *algo, char *string, unsigned char *hash);
+    void getHashFromStringIter(HashAlgorithm *algo, char *string, unsigned char *hash, int numIterations);
+    unsigned char* convertHashStringToBinary(HashAlgorithm *algo, char *hashString);
 
 #ifdef	__cplusplus
 }

--- a/helper.c
+++ b/helper.c
@@ -286,11 +286,7 @@ static void print_validation_errstr(long verify_result) {
 }
 
 int openssl_check_certificate_callback(int verify_result, X509_STORE_CTX *ctx) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-    X509* cert = ctx->cert;
-#else
     X509* cert = X509_STORE_CTX_get0_cert(ctx);
-#endif
     
     struct xdccGetConfig *cfg = getCfg();
     

--- a/libircclient-src/colors.c
+++ b/libircclient-src/colors.c
@@ -46,7 +46,7 @@ static inline void libirc_colorparser_addorcat(char ** destline, unsigned int * 
     unsigned int len = strlen(str);
 
     if (*destline) {
-        strncpy(*destline, str, len);
+        memcpy(*destline, str, len);
         *destline += len;
     }
     else

--- a/libircclient-src/libircclient.c
+++ b/libircclient-src/libircclient.c
@@ -608,7 +608,7 @@ int irc_send_raw(irc_session_t * session, const char * format, ...) {
         return 1;
     }
 
-    strncpy(session->outgoing_buf + session->outgoing_offset, buf, strlen(buf));
+    memcpy(session->outgoing_buf + session->outgoing_offset, buf, strlen(buf));
     session->outgoing_offset += strlen(buf);
     session->outgoing_buf[session->outgoing_offset++] = 0x0D;
     session->outgoing_buf[session->outgoing_offset++] = 0x0A;

--- a/xdccget.c
+++ b/xdccget.c
@@ -118,10 +118,10 @@ void* checksum_verification_thread(void *args) {
     logprintf(LOG_INFO, "Verifying md5-checksum '%s'!", md5ChecksumString);
 
     HashAlgorithm *md5algo = createHashAlgorithm("MD5");
-    uchar hashFromFile[md5algo->hashSize];
+    unsigned char hashFromFile[md5algo->hashSize];
 
     getHashFromFile(md5algo, data->completePath , hashFromFile);
-    uchar *expectedHash = convertHashStringToBinary(md5algo, md5ChecksumString);
+    unsigned char *expectedHash = convertHashStringToBinary(md5algo, md5ChecksumString);
 
     if (md5algo->equals(expectedHash, hashFromFile)) {
         logprintf(LOG_INFO, "Checksum-Verification succeeded!");


### PR DESCRIPTION
* Replace SPH MD5 with OpenSSL MD5
Derivated from @mario-campos fork. Put into a single commit. Includes a tiny typo fix.
Results in smaller binary size and using a maintained external library is preferable.

* Remove obsolete check for OpenSSL below 1.1.x
As OpenSSL 1.1.x is a must due to changes in ssl.c anyway.

* Substitute strncpy with memcpy
Substitute strncpy with memcpy, if strlen(buf) is used to properly fix gcc 9+ compiler warnings like:
"warning: 'strncpy' output truncated before terminating nul copying X bytes from a string..."
Seems to work, but I'm not aware of every edge case...